### PR TITLE
Feature - Adds phpmyadmin access

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,22 @@ services:
       MYSQL_PASSWORD: wordpress
     networks:
       - wpsite
+  
+  # PHPMyAdmin
+  phpmyadmin:
+    depends_on:
+      - db
+    image: phpmyadmin/phpmyadmin
+    restart: always
+    ports:
+      - '8080:80'
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: password
+    networks:
+      - wpsite
+  
+  # WordPress
   wordpress:
     depends_on:
       - db


### PR DESCRIPTION
## Overview
Add access for PHPMyAdmin portal.

## Description
As a developer I want to add support for PHPMyAdmin portal so that databases are easily accessible. 

## Testing Instructions
1. Checkout this branch locally.
2. Run ``` docker-compose up ``` from your terminal in this directory.
3. Visit localhost:8080 on your browser and use 'root' for username and 'password' for password to log into PhpMyAdmin and view all databases.